### PR TITLE
Fix webring link direction

### DIFF
--- a/templates/default.html
+++ b/templates/default.html
@@ -24,8 +24,8 @@
                     </div>
                     <hr class="social-hr">
                     <div class="webring">
-                      <a href="https://hotlinewebring.club/tonyd/next"><i class="fa fa-hand-o-left fa-lg"></i></a>
-                      <a href="https://hotlinewebring.club/tonyd/previous"><i class="fa fa-hand-o-right fa-lg"></i></a>
+                      <a href="https://hotlinewebring.club/tonyd/previous"><i class="fa fa-hand-o-left fa-lg"></i></a>
+                      <a href="https://hotlinewebring.club/tonyd/next"><i class="fa fa-hand-o-right fa-lg"></i></a>
                     </div>
                 </div>
                 <div class="col-lg-10 col-md-9 col-sm-9">


### PR DESCRIPTION
The icons were switched: the left-pointing hand was going to the next link, and the right-pointing hand was going to the previous link.
